### PR TITLE
Remove dependency on the use of spaces inside DEFINE_SERIALIZABLE

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -24,7 +24,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
           -Wextra
           -Wno-c++98-compat
           -Wno-c++98-compat-pedantic
-          -Wno-missing-prototypes
           -Wno-exit-time-destructors
           # it would be nice if googletest could fix their clang warnings :-)
           -Wno-undef

--- a/include/tser/base64_encoding.hpp
+++ b/include/tser/base64_encoding.hpp
@@ -13,7 +13,7 @@ namespace tser {
         unsigned val = 0;
         int valb = -6;
         for (char c : in) {
-            val = (val << 8) + c;
+            val = (val << 8) + static_cast<unsigned>(c);
             valb += 8;
             while (valb >= 0) {
                 out.push_back(g_encodingTable[(val >> valb) & 0x3F]);
@@ -28,7 +28,7 @@ namespace tser {
         unsigned val = 0;
         int valb = -8;
         for (char c : in) {
-            val = (val << 6) + g_decodingTable[static_cast<unsigned char>(c)];
+            val = (val << 6) + static_cast<unsigned>(g_decodingTable[static_cast<unsigned char>(c)]);
             valb += 6;
             if (valb >= 0) {
                 out.push_back(char((val >> valb) & 0xFF));

--- a/include/tser/base64_encoding.hpp
+++ b/include/tser/base64_encoding.hpp
@@ -10,7 +10,8 @@ namespace tser {
     static constexpr auto g_decodingTable = []() { std::array<char, 256> decTable{}; for (char i = 0; i < 64; ++i) decTable[static_cast<unsigned>(g_encodingTable[static_cast<size_t>(i)])] = i; return decTable; }();
     static std::string encode_base64(std::string_view in) {
         std::string out;
-        int val = 0, valb = -6;
+        unsigned val = 0;
+        int valb = -6;
         for (char c : in) {
             val = (val << 8) + c;
             valb += 8;
@@ -24,7 +25,8 @@ namespace tser {
     }
     static std::string decode_base64(std::string_view in) {
         std::string out;
-        int val = 0, valb = -8;
+        unsigned val = 0;
+        int valb = -8;
         for (char c : in) {
             val = (val << 6) + g_decodingTable[static_cast<unsigned char>(c)];
             valb += 6;

--- a/include/tser/tser.hpp
+++ b/include/tser/tser.hpp
@@ -33,7 +33,8 @@ namespace tser{
         template<template<typename, size_t> class TArray, typename T, size_t N>
         struct is_array<TArray<T, N>> : std::true_type {};
         constexpr size_t n_args(char const* c, size_t nargs = 1) {
-            for (; *c; ++c) if (*c == ',') ++nargs; return nargs;
+            for (; *c; ++c) if (*c == ',') ++nargs;
+            return nargs;
         }
         constexpr size_t str_size(char const* c, size_t strSize = 1) {
             for (; *c; ++c) ++strSize; return strSize;

--- a/include/tser/tser.hpp
+++ b/include/tser/tser.hpp
@@ -36,8 +36,33 @@ namespace tser{
             for (; *c; ++c) if (*c == ',') ++nargs;
             return nargs;
         }
-        constexpr size_t str_size(char const* c, size_t strSize = 1) {
-            for (; *c; ++c) ++strSize; return strSize;
+
+        template <size_t Length>
+        constexpr auto make_name_data(const char (&args)[Length]) {
+            std::array<char, Length> chars{};
+            for (size_t i = 0; i < Length; i++) {
+                const char ch = args[i];
+                if (ch != ',' && ch != ' ') {
+                    chars[i] = ch;
+                }
+            }
+            return chars;
+        }
+
+        template <size_t Length>
+        constexpr auto make_names(const std::array<char, Length>& data) {
+            std::array<const char*, Length> names{};
+            const char ** out = names.data();
+            const char * currentName = data.data();
+            for (const char& ch : data) {
+                if (ch == '\0' && currentName != nullptr) {
+                    *out++ = currentName;
+                    currentName = nullptr;
+                } else if (ch != '\0' && currentName == nullptr) {
+                    currentName = &ch;
+                }
+            }
+            return names;
         }
     }
     // we need a bunch of template metaprogramming for being able to differentiate between different types 
@@ -237,15 +262,9 @@ namespace tser{
 #define DEFINE_SERIALIZABLE(Type, ...) \
 inline decltype(auto) members() const { return std::tie(__VA_ARGS__); } \
 inline decltype(auto) members() { return std::tie(__VA_ARGS__); }  \
-static constexpr std::array<char, tser::detail::str_size(#__VA_ARGS__)> _memberNameData = [](){ \
-std::array<char, tser::detail::str_size(#__VA_ARGS__)> chars{}; size_t idx = 0; constexpr auto* ini(#__VA_ARGS__);  \
-for (char const* c = ini; *c; ++c, ++idx) if(*c != ',') chars[idx] = *c;  return chars;}(); \
+static constexpr auto _memberNameData = tser::detail::make_name_data(#__VA_ARGS__); \
 static constexpr const char* _typeName = #Type; \
-static constexpr std::array<const char*, tser::detail::n_args(#__VA_ARGS__)> _memberNames = \
-[](){ std::array<const char*, tser::detail::n_args(#__VA_ARGS__)> out{ {Type::_memberNameData.data()} }; \
-for(size_t i = 0, nArgs = 0; i < Type::_memberNameData.size() - 1; ++i) \
-if (Type::_memberNameData[i] == '\0'){++nArgs; out[nArgs] = &Type::_memberNameData[i] + 1;} \
-return out;}();\
+static constexpr auto _memberNames = tser::detail::make_names(Type::_memberNameData); \
 template<typename OT, std::enable_if_t<std::is_same_v<OT,Type> && !tser::is_detected_v<tser::has_equal_t, OT>, int> = 0>\
 friend bool operator==(const Type& lhs, const OT& rhs) { return lhs.members() == rhs.members(); }\
 template<typename OT, std::enable_if_t<std::is_same_v<OT,Type> && !tser::is_detected_v<tser::has_nequal_t, OT>, int> = 0>\

--- a/include/tser/tser.hpp
+++ b/include/tser/tser.hpp
@@ -86,6 +86,8 @@ namespace tser{
         else if constexpr (is_detected_v<has_optional_t, V> && !is_detected_v<has_element_t, V>) {
             os << (val ? (os << (tser::print(os, *val)), "") : "null");
         }
+        else if constexpr (is_detected_v<has_element_t, V>)
+            os << val.get();
         else
             os << val;
         return "";

--- a/single_header/tser/tser.hpp
+++ b/single_header/tser/tser.hpp
@@ -49,7 +49,7 @@ namespace tser {
         unsigned val = 0;
         int valb = -6;
         for (char c : in) {
-            val = (val << 8) + c;
+            val = (val << 8) + static_cast<unsigned>(c);
             valb += 8;
             while (valb >= 0) {
                 out.push_back(g_encodingTable[(val >> valb) & 0x3F]);
@@ -64,7 +64,7 @@ namespace tser {
         unsigned val = 0;
         int valb = -8;
         for (char c : in) {
-            val = (val << 6) + g_decodingTable[static_cast<unsigned char>(c)];
+            val = (val << 6) + static_cast<unsigned>(g_decodingTable[static_cast<unsigned char>(c)]);
             valb += 6;
             if (valb >= 0) {
                 out.push_back(char((val >> valb) & 0xFF));
@@ -101,33 +101,8 @@ namespace tser{
             for (; *c; ++c) if (*c == ',') ++nargs;
             return nargs;
         }
-
-        template <size_t Length>
-        constexpr auto make_name_data(const char (&args)[Length]) {
-            std::array<char, Length> chars{};
-            for (size_t i = 0; i < Length; i++) {
-                const char ch = args[i];
-                if (ch != ',' && ch != ' ') {
-                    chars[i] = ch;
-                }
-            }
-            return chars;
-        }
-
-        template <size_t Length>
-        constexpr auto make_names(const std::array<char, Length>& data) {
-            std::array<const char*, Length> names{};
-            const char ** out = names.data();
-            const char * currentName = data.data();
-            for (const char& ch : data) {
-                if (ch == '\0' && currentName != nullptr) {
-                    *out++ = currentName;
-                    currentName = nullptr;
-                } else if (ch != '\0' && currentName == nullptr) {
-                    currentName = &ch;
-                }
-            }
-            return names;
+        constexpr size_t str_size(char const* c, size_t strSize = 1) {
+            for (; *c; ++c) ++strSize; return strSize;
         }
     }
     // we need a bunch of template metaprogramming for being able to differentiate between different types 
@@ -327,14 +302,20 @@ namespace tser{
 #define DEFINE_SERIALIZABLE(Type, ...) \
 inline decltype(auto) members() const { return std::tie(__VA_ARGS__); } \
 inline decltype(auto) members() { return std::tie(__VA_ARGS__); }  \
-static constexpr auto _memberNameData = tser::detail::make_name_data(#__VA_ARGS__); \
+static constexpr std::array<char, tser::detail::str_size(#__VA_ARGS__)> _memberNameData = [](){ \
+std::array<char, tser::detail::str_size(#__VA_ARGS__)> chars{'\0'}; size_t idx = 0; constexpr auto* ini(#__VA_ARGS__);  \
+for (char const* c = ini; *c; ++c, ++idx) if(*c != ',' && *c != ' ') chars[idx] = *c;  return chars;}(); \
 static constexpr const char* _typeName = #Type; \
-static constexpr auto _memberNames = tser::detail::make_names(Type::_memberNameData); \
+static constexpr std::array<const char*, tser::detail::n_args(#__VA_ARGS__)> _memberNames = \
+[](){ std::array<const char*, tser::detail::n_args(#__VA_ARGS__)> out{ }; \
+for(size_t i = 0, nArgs = 0; nArgs < tser::detail::n_args(#__VA_ARGS__) ; ++i) { \
+while(Type::_memberNameData[i] == '\0') i++; out[nArgs++] = &Type::_memberNameData[i]; \
+while(Type::_memberNameData[++i] != '\0'); } return out;}();\
 template<typename OT, std::enable_if_t<std::is_same_v<OT,Type> && !tser::is_detected_v<tser::has_equal_t, OT>, int> = 0>\
 friend bool operator==(const Type& lhs, const OT& rhs) { return lhs.members() == rhs.members(); }\
 template<typename OT, std::enable_if_t<std::is_same_v<OT,Type> && !tser::is_detected_v<tser::has_nequal_t, OT>, int> = 0>\
 friend bool operator!=(const Type& lhs, const OT& rhs) { return !(lhs == rhs); }\
 template<typename OT, std::enable_if_t<std::is_same_v<OT,Type> && !tser::is_detected_v<tser::has_smaller_t, OT>, int> = 0>\
 friend bool operator< (const OT& lhs, const OT& rhs) { return tser::less(lhs, rhs); } \
-template<typename OT, std::enable_if_t<std::is_same_v<OT, Type> && !tser::is_detected_v<tser::has_outstream_op_t, OT>, int> = 0>\
+template<typename OT, std::enable_if_t<std::is_same_v<OT,Type> && !tser::is_detected_v<tser::has_outstream_op_t, OT>, int> = 0>\
 friend std::ostream& operator<<(std::ostream& os, const OT& t) { tser::print(os, t); return os; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
           -Wextra
           -Wno-c++98-compat
           -Wno-c++98-compat-pedantic
-          -Wno-missing-prototypes
           # it would be nice if googletest could fix their clang warnings :-)
           -Wno-undef
           -Wno-global-constructors

--- a/test/SerializeTest.cpp
+++ b/test/SerializeTest.cpp
@@ -175,10 +175,10 @@ struct ThirdPartyStruct {
 };
 
 namespace tser {
-    void operator<<(const ThirdPartyStruct& t, tser::BinaryArchive& ba) {
+    static void operator<<(const ThirdPartyStruct& t, tser::BinaryArchive& ba) {
         ba.save(t.x + t.y);
     }
-    void operator>>(ThirdPartyStruct& t, tser::BinaryArchive& ba) {
+    static void operator>>(ThirdPartyStruct& t, tser::BinaryArchive& ba) {
         t.x = ba.load<int>();
     }
 }

--- a/test/SerializeTest.cpp
+++ b/test/SerializeTest.cpp
@@ -3,9 +3,10 @@
 #include "gtest/gtest.h"
 #include "tser/tser.hpp"
 
+#include <optional>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
-#include <optional>
 
 //if you need deep pointer comparisions you could grab this macro
 namespace tser::detail {
@@ -283,4 +284,64 @@ TEST(fixed_size, array_carray)
     constexpr int num[5]{};
     static_assert(tser::detail::is_array<decltype(num)>::value);
     static_assert(!tser::detail::is_array<std::vector<int>>::value);
+}
+
+
+struct MacroNoSpace
+{
+    DEFINE_SERIALIZABLE(MacroNoSpace,i,j,k)
+    int i = 3;
+    int j = 1;
+    int k = 4;
+};
+
+struct MacroSomeSpace
+{
+    DEFINE_SERIALIZABLE(MacroSomeSpace, i, j, k)
+    int i = 3;
+    int j = 1;
+    int k = 4;
+};
+
+struct MacroCrazySpace
+{
+    DEFINE_SERIALIZABLE(
+        MacroCrazySpace  ,
+    i ,
+    		j   ,
+        k
+    )
+    int i = 3;
+    int j = 1;
+    int k = 4;
+};
+
+template <typename Type>
+void TestMacroSpaces(const char * name)
+{
+    std::stringstream stream;
+    Type type;
+    stream << type;
+
+    const char macroExpectationFormat[] =
+        "{ \"%s\": {\"i\" : 3, \"j\" : 1, \"k\" : 4}}\n";
+
+    char expectation[128];
+    snprintf(expectation, sizeof(expectation), macroExpectationFormat, name);
+    ASSERT_EQ(stream.str(), expectation);
+}
+
+TEST(macroSpaces, noSpace)
+{
+    TestMacroSpaces<MacroNoSpace>("MacroNoSpace");
+}
+
+TEST(macroSpaces, someSpace)
+{
+    TestMacroSpaces<MacroSomeSpace>("MacroSomeSpace");
+}
+
+TEST(macroSpaces, crazySpace)
+{
+    TestMacroSpaces<MacroCrazySpace>("MacroCrazySpace");
 }

--- a/test/SerializeTest.cpp
+++ b/test/SerializeTest.cpp
@@ -89,7 +89,8 @@ TEST(binaryArchive, readArray)
 TEST(binaryArchive, readRawPtr)
 {
     tser::BinaryArchive binaryArchive;
-    auto someArray = new std::string("Hello World!");
+    std::string testStr("Hello World!");
+    auto * someArray = &testStr;
     binaryArchive << someArray;
     ASSERT_TRUE(*std::unique_ptr<std::string>(binaryArchive.load<decltype(someArray)>()) == "Hello World!");
 }

--- a/test/SerializeTest.cpp
+++ b/test/SerializeTest.cpp
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 #include "tser/tser.hpp"
 
+#include <numeric>
 #include <optional>
 #include <sstream>
 #include <unordered_map>
@@ -44,17 +45,39 @@ TEST(binaryArchive, readBits)
     ASSERT_TRUE(binaryArchive.load<bool>());
 }
 
+template <typename Integer>
+void TestIntegerSerialisation()
+{
+    std::array<long long, 3000> integerSequence;
+    std::iota(integerSequence.begin(), integerSequence.end(), 0);
+
+    tser::BinaryArchive binaryArchive;
+
+    for (auto i : integerSequence) {
+        binaryArchive.save(static_cast<Integer>(i));
+        binaryArchive.save(static_cast<Integer>(-i));
+    }
+
+    binaryArchive.reset();
+
+    for (auto i : integerSequence) {
+        ASSERT_EQ(binaryArchive.load<Integer>(), static_cast<Integer>(i));
+        ASSERT_EQ(binaryArchive.load<Integer>(), static_cast<Integer>(-i));
+    }
+}
 
 TEST(binaryArchive, readInts)
 {
-    tser::BinaryArchive binaryArchive;
-    binaryArchive.save(15);
-    binaryArchive.save(256);
-    binaryArchive.save(-256);
-    binaryArchive.reset();
-    ASSERT_TRUE(binaryArchive.load<int>() == 15);
-    ASSERT_TRUE(binaryArchive.load<int>() == 256);
-    ASSERT_TRUE(binaryArchive.load<int>() == -256);
+    TestIntegerSerialisation<signed char>();
+    TestIntegerSerialisation<unsigned char>();
+    TestIntegerSerialisation<signed short>();
+    TestIntegerSerialisation<unsigned short>();
+    TestIntegerSerialisation<signed int>();
+    TestIntegerSerialisation<unsigned int>();
+    TestIntegerSerialisation<signed long>();
+    //TestIntegerSerialisation<unsigned long>();
+    TestIntegerSerialisation<signed long long>();
+    //TestIntegerSerialisation<unsigned long long>();
 }
 
 enum class SomeEnum { A, B, C };


### PR DESCRIPTION
I saw this library posted on reddit earlier and wondered how the member parsing worked, and upon inspection I spotted what looked like a bug due to the splitting of parameters on `,` in `DEFINE_SERIALIZABLE()`. It didn't look like you had any tests for that particular case so I set one up and it did indeed fail.

The issue in question was that `DEFINE_SERIALIZABLE(a,b,c)` and `DEFINE_SERIALIZABLE(a, b, c)` behaved differently because the spaces became part of the serialised name. This is fixed with 037e3997c42998b94ef21ffe37e65abc73e4d9a6.

I've also got it building again on Linux (ie with GCC and clang) since they weren't building, and removed some warnings that they were generating too. I've also given it a pass with ASAN and UBSan to check for any other issues and fixed the easy ones, but there are some follow up issues that need looking at, most notably serialisation failing for 64bit integer types (see ba66359253aa9c12586d7ee9ba013aa6b61ff9d4). These issues are:

The build fails when using `libc++` rather than `libstdc++` (you do this by passing `-stdlib=libc++` when compiling with clang):
```
tser/example/example2.cpp:114:19: error: invalid operands to binary expression ('std::__1::ostream' (aka 'basic_ostream<char>') and 'cpp_serializers_benchmark::Monster')
        std::cout << m << "\n";
        ~~~~~~~~~ ^  ~
tser/example/example2.cpp:43:9: note: candidate template ignored: requirement '!tser::is_detected_v<tser::has_outstream_op_t, cpp_serializers_benchmark::Monster>' was not satisfied [with OT = cpp_serializers_benchmark::Monster]
        DEFINE_SERIALIZABLE(Monster,pos,mana,hp,name,inventory,color,weapons,equipped,path)
        ^
tser/include/tser/tser.hpp:276:22: note: expanded from macro 'DEFINE_SERIALIZABLE'
friend std::ostream& operator<<(std::ostream& os, const OT& t) { tser::print(os, t); return os; }
```

GCC doesn't understand some of the compiler options and issues some warnings about them:
```
cc1plus: note: unrecognized command-line option ‘-Wno-shift-sign-overflow’
cc1plus: note: unrecognized command-line option ‘-Wno-exit-time-destructors’
cc1plus: note: unrecognized command-line option ‘-Wno-language-extension-token’
cc1plus: note: unrecognized command-line option ‘-Wno-global-constructors’
cc1plus: note: unrecognized command-line option ‘-Wno-c++98-compat-pedantic’
cc1plus: note: unrecognized command-line option ‘-Wno-c++98-compat’
```

UBSan has picked up an invalid shift:
```
tser/include/tser/varint_encoding.hpp:10:42: runtime error: left shift of negative value -1
```

I'm not actually using this library and it was curiosity that lead me here, so I guess those issues are in your hands now :P